### PR TITLE
per-file replacement function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@ var stream = require('stream');
 
 module.exports = function(search, replacement) {
   var doReplace = function(file, callback) {
+
+    if (typeof search === 'function') {
+      var args = search(file);
+      search = args.search;
+      replacement = args.replacement;
+    }
+
     var isRegExp = search instanceof RegExp;
     var isStream = file.contents && typeof file.contents.on === 'function' && typeof file.contents.pipe === 'function';
     var isBuffer = file.contents instanceof Buffer;

--- a/test/main.js
+++ b/test/main.js
@@ -142,5 +142,33 @@ describe('gulp-replace', function() {
       stream.write(file);
       stream.end();
     });
+    it('should call the function to generate the arguments, when the first argument is a function', function (done) {
+      var file = new gutil.File({
+        path: 'test/fixtures/helloworld.txt',
+        cwd: 'test/',
+        base: 'test/fixtures',
+        contents: fs.readFileSync('test/fixtures/helloworld.txt')
+      });
+
+      var stream = replacePlugin(function (file) {
+        'test/fixtures/helloworld.txt'.should.equal(file.path);
+        return {
+          search: /world/g,
+          replacement: 'person'
+        };
+      });
+
+      stream.on('data', function(newFile) {
+        should.exist(newFile);
+        should.exist(newFile.contents);
+
+        String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+        done();
+      });
+
+      stream.write(file);
+      stream.end();
+
+    });
   });
 });


### PR DESCRIPTION
This PR allows you to do the replacement differently depending on the file.

For example, to pass all relative urls in a a project to absolute ones, you need to know the location of the file.

``` javascript
.pipe(replace(function (file) {
  return {
    search: url_regex,
    replacement: _.partial(replacement_function, file.path)
  };
}))
```

So if you pass a function to `replace` it runs it with the file as the argument. This function should return the arguments for the normal replacement process.

I'm not sure if this a good approach, as I don't like changing the signature of the replace function, but I can't think of another way to do this.
