### PR TITLE
Trivial documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Type: `String` or `Function`
 
 The replacement string or function. If `replacement` is a function, it will be called once for each match and will be passed the string that is to be replaced.
 
-### replace(regex, replace)
+### replace(regex, replacement)
 
 *Note:* gulp-replace cannot perform regex replacement on streams.
 


### PR DESCRIPTION
Changed 'replace' to 'replacement' in the regex version of the API call, so that it's clear that the second parameter is the same (neglecting the distinction of referencing matched text) regardless of whether you're performing string or regex matching
