### PR TITLE
Hardcode istextorbinary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "event-stream": "^3.1.7",
     "replacestream": "1.0.2",
-    "istextorbinary": "^1.0.0"
+    "istextorbinary": "1.0.0"
   },
   "devDependencies": {
     "should": "^4.1.0",


### PR DESCRIPTION
Newly released v1.0.1 of istextorbinary contains no code. This is a temporary fix until they push a new release.

See issue below:
https://github.com/bevry/istextorbinary/issues/3