### PR TITLE
chore(deps) bump istextorbinary to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "event-stream": "3.2.1",
     "replacestream": "1.0.2",
-    "istextorbinary": "1.0.0"
+    "istextorbinary": "1.0.2"
   },
   "devDependencies": {
     "should": "^4.6.0",


### PR DESCRIPTION
Given it was fixed earlier today and republished, might as well take the slightly lighter install without the unused _safefs_ module.