### PR TITLE
Use through2 instead of event-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - 0.10

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "gulp-replace",
   "version": "0.5.2",
   "description": "A string replace plugin for gulp",
-  "main": "index.js",
   "dependencies": {
-    "event-stream": "3.2.1",
-    "replacestream": "2.0.0",
-    "istextorbinary": "1.0.2"
+    "istextorbinary": "1.0.2",
+    "replacestream": "^2.0.0",
+    "through2": "^0.6.3"
   },
   "devDependencies": {
     "should": "^4.6.0",
@@ -14,7 +13,7 @@
     "gulp-util": "^3.0.2"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "through2": "^0.6.3"
   },
   "devDependencies": {
-    "should": "^4.6.0",
+    "event-stream": "^3.2.1",
     "mocha": "^2.1.0",
-    "gulp-util": "^3.0.2"
+    "should": "^4.6.0",
+    "vinyl": "^0.4.6"
   },
   "scripts": {
     "test": "mocha"

--- a/test/main.js
+++ b/test/main.js
@@ -356,7 +356,7 @@ describe('gulp-replace', function() {
       });
 
       var stream = replacePlugin('world', 'elephant')
-      .on('end', function() {
+      .on('finish', function() {
         // No assertion required, we should end up here, if we don't the test will time out 
         done();
       });

--- a/test/main.js
+++ b/test/main.js
@@ -1,15 +1,16 @@
+'use strict';
+
 var replacePlugin = require('../');
 var fs = require('fs');
-var path = require('path');
 var es = require('event-stream');
 var should = require('should');
-var gutil = require('gulp-util');
+var File = require('vinyl');
 require('mocha');
 
 describe('gulp-replace', function() {
   describe('replacePlugin()', function() {
     it('should replace string on a stream', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -33,7 +34,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace string on a buffer', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -54,7 +55,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace regex on a stream', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -78,7 +79,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace regex on a buffer', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -99,7 +100,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace regex on a stream with a function', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -123,7 +124,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace regex on a buffer with a function', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -144,7 +145,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace string on a stream with a function', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -168,7 +169,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace string on a buffer with a function', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -189,7 +190,7 @@ describe('gulp-replace', function() {
     });
 
     it('should call function once for each replacement when replacing a string on a stream', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -219,7 +220,7 @@ describe('gulp-replace', function() {
     });
 
     it('should call function once for each replacement when replacing a regex on a stream', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -249,7 +250,7 @@ describe('gulp-replace', function() {
     });
 
     it('should call function once for each replacement when replacing a string on a buffer', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -276,7 +277,7 @@ describe('gulp-replace', function() {
     });
 
     it('should call function once for each replacement when replacing a regex on a buffer', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -303,7 +304,7 @@ describe('gulp-replace', function() {
     });
 
     it('should ignore binary files when skipBinary is enabled', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/binary.png',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -324,7 +325,7 @@ describe('gulp-replace', function() {
     });
 
     it('should replace string on non binary files when skipBinary is enabled', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -348,7 +349,7 @@ describe('gulp-replace', function() {
     });
 
     it('should trigger events on a stream', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
         base: 'test/fixtures',

--- a/test/realworld.js
+++ b/test/realworld.js
@@ -1,15 +1,15 @@
+'use strict';
+
 var replacePlugin = require('../');
 var fs = require('fs');
-var path = require('path');
-var es = require('event-stream');
 var should = require('should');
-var gutil = require('gulp-util');
+var File = require('vinyl');
 require('mocha');
 
 describe('gulp-replace', function() {
   describe('real world use cases', function() {
     it('drop use strict on a buffer', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/strict.js',
         cwd: 'test/',
         base: 'test/fixtures',
@@ -30,7 +30,7 @@ describe('gulp-replace', function() {
     });
 
     it('replace script versions in HTML', function(done) {
-      var file = new gutil.File({
+      var file = new File({
         path: 'test/fixtures/scriptpage.html',
         cwd: 'test/',
         base: 'test/fixtures',


### PR DESCRIPTION
* I replaced [event-stream](https://github.com/dominictarr/event-stream) with [through2](https://github.com/rvagg/through2).

  According to [the acceptance test suite for gulp plugins](https://github.com/gulpjs/acceptance), [it is not recommended that a gulp plugin depends on event-stream](https://github.com/gulpjs/acceptance#dependencies).

  > **Reason** Old streams + bloated kitchen sink

  Actually, this plugin doesn't use gazillions of event-stream's methods.
* I replaced [gulp-util](https://github.com/gulpjs/gulp-util) with [vinyl](https://github.com/wearefractal/vinyl). gulp-util will be deprecated. https://github.com/gulpjs/gulp/issues/360
