### PR TITLE
Switch from Streams2 to Streams3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,76 +1,77 @@
 'use strict';
 
-var through = require('through2');
+var Transform = require('readable-stream/transform');
 var rs = require('replacestream');
 var istextorbinary = require('istextorbinary');
 
 module.exports = function(search, replacement, options) {
-  var doReplace = function(file, enc, callback) {
-    if (file.isNull()) {
-      return callback(null, file);
-    }
-
-    function doReplace() {
-      if (file.isStream()) {
-        file.contents = file.contents.pipe(rs(search, replacement));
+  return new Transform({
+    objectMode: true,
+    transform: function(file, enc, callback) {
+      if (file.isNull()) {
         return callback(null, file);
       }
 
-      if (file.isBuffer()) {
-        if (search instanceof RegExp) {
-          file.contents = new Buffer(String(file.contents).replace(search, replacement));
+      function doReplace() {
+        if (file.isStream()) {
+          file.contents = file.contents.pipe(rs(search, replacement));
+          return callback(null, file);
         }
-        else {
-          var chunks = String(file.contents).split(search);
 
-          var result;
-          if (typeof replacement === 'function') {
-            // Start with the first chunk already in the result
-            // Replacements will be added thereafter
-            // This is done to avoid checking the value of i in the loop
-            result = [ chunks[0] ];
-
-            // The replacement function should be called once for each match
-            for (var i = 1; i < chunks.length; i++) {
-              // Add the replacement value
-              result.push(replacement(search));
-
-              // Add the next chunk
-              result.push(chunks[i]);
-            }
-
-            result = result.join('');
+        if (file.isBuffer()) {
+          if (search instanceof RegExp) {
+            file.contents = new Buffer(String(file.contents).replace(search, replacement));
           }
           else {
-            result = chunks.join(replacement);
-          }
+            var chunks = String(file.contents).split(search);
 
-          file.contents = new Buffer(result);
+            var result;
+            if (typeof replacement === 'function') {
+              // Start with the first chunk already in the result
+              // Replacements will be added thereafter
+              // This is done to avoid checking the value of i in the loop
+              result = [ chunks[0] ];
+
+              // The replacement function should be called once for each match
+              for (var i = 1; i < chunks.length; i++) {
+                // Add the replacement value
+                result.push(replacement(search));
+
+                // Add the next chunk
+                result.push(chunks[i]);
+              }
+
+              result = result.join('');
+            }
+            else {
+              result = chunks.join(replacement);
+            }
+
+            file.contents = new Buffer(result);
+          }
+          return callback(null, file);
         }
-        return callback(null, file);
+
+        callback(null, file);
       }
 
-      callback(null, file);
-    }
-
-    if (options && options.skipBinary) {
-      istextorbinary.isText('', file.contents, function(err, result) {
-        if (err) {
-          return callback(err, file);
-        }
+      if (options && options.skipBinary) {
+        istextorbinary.isText('', file.contents, function(err, result) {
+          if (err) {
+            return callback(err, file);
+          }
         
-        if (!result) {
-          callback(null, file);
-        } else {
-          doReplace();
-        }
-      });
+          if (!result) {
+            callback(null, file);
+          } else {
+            doReplace();
+          }
+        });
 
-      return;
-    } 
+        return;
+      } 
 
-    doReplace();
-  };
-
-  return through.obj(doReplace);
+      doReplace();
+    }
+  });
 };

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "A string replace plugin for gulp",
   "dependencies": {
     "istextorbinary": "1.0.2",
-    "replacestream": "2.0.0",
-    "through2": "0.6.3"
+    "readable-stream": "^2.0.1",
+    "replacestream": "^4.0.0"
   },
   "devDependencies": {
-    "event-stream": "^3.2.2",
+    "concat-stream": "^1.5.0",
     "mocha": "^2.1.0",
-    "should": "^5.0.0",
-    "vinyl": "^0.4.6"
+    "should": "^7.0.1",
+    "vinyl": "^0.5.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/main.js
+++ b/test/main.js
@@ -1,11 +1,10 @@
 'use strict';
 
+var concatStream = require('concat-stream');
 var replacePlugin = require('../');
 var fs = require('fs');
-var es = require('event-stream');
 var should = require('should');
 var File = require('vinyl');
-require('mocha');
 
 describe('gulp-replace', function() {
   describe('replacePlugin()', function() {
@@ -22,8 +21,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         }));
@@ -67,8 +65,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         }));
@@ -112,8 +109,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         }));
@@ -157,8 +153,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         }));
@@ -208,8 +203,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
           done();
         }));
@@ -238,8 +232,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
           done();
         }));
@@ -337,8 +330,7 @@ describe('gulp-replace', function() {
         should.exist(newFile);
         should.exist(newFile.contents);
 
-        newFile.contents.pipe(es.wait(function(err, data) {
-          should.not.exist(err);
+        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
           data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         }));

--- a/test/realworld.js
+++ b/test/realworld.js
@@ -4,7 +4,6 @@ var replacePlugin = require('../');
 var fs = require('fs');
 var should = require('should');
 var File = require('vinyl');
-require('mocha');
 
 describe('gulp-replace', function() {
   describe('real world use cases', function() {


### PR DESCRIPTION
The current latest version of gulp-replace uses Streams2 via the [through2](https://github.com/dominictarr/through) v0.6 but Streams2 is an older implementation.

This PR replaces through2 v0.6 with [readable-stream](https://github.com/nodejs/readable-stream) v2.0 to switch to Streams3 which is a more popular stream implementation as it's used in the latest Node and io.js.
