### PR TITLE
fixed text file detecting

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,11 +56,11 @@ module.exports = function(search, replacement, options) {
       }
 
       if (options && options.skipBinary) {
-        istextorbinary.isText('', file.contents, function(err, result) {
+        istextorbinary.isText(file.path, file.contents, function(err, result) {
           if (err) {
             return callback(err, file);
           }
-        
+
           if (!result) {
             callback(null, file);
           } else {
@@ -69,7 +69,7 @@ module.exports = function(search, replacement, options) {
         });
 
         return;
-      } 
+      }
 
       doReplace();
     }


### PR DESCRIPTION
"uglify" js file will be detected to binary file if `filename` omitted in 'istextorbinary' module