### PR TITLE
Tests refactoring

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -8,6 +8,128 @@ var File = require('vinyl');
 
 describe('gulp-replace', function() {
   describe('replacePlugin()', function() {
+    describe('buffered input', function () {
+      var file;
+
+      beforeEach(function () {
+        file = new File({
+          path: 'test/fixtures/helloworld.txt',
+          cwd: 'test/',
+          base: 'test/fixtures',
+          contents: fs.readFileSync('test/fixtures/helloworld.txt')
+        });
+      });
+
+      it('should replace string on a buffer', function(done) {
+        var stream = replacePlugin('world', 'person');
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should replace regex on a buffer', function(done) {
+        var stream = replacePlugin(/world/g, 'person');
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should replace regex on a buffer with a function', function(done) {
+        var stream = replacePlugin(/world/g, function() { return 'person'; });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should replace string on a buffer with a function', function(done) {
+        var stream = replacePlugin('world', function() { return 'person'; });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+
+      it('should call function once for each replacement when replacing a string on a buffer', function(done) {
+        var replacements = [
+          'cow',
+          'chicken',
+          'duck',
+          'person'
+        ];
+        var stream = replacePlugin('world', function() { return replacements.shift(); });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+
+      it('should call function once for each replacement when replacing a regex on a buffer', function(done) {
+        var replacements = [
+          'cow',
+          'chicken',
+          'duck',
+          'person'
+        ];
+        var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should trigger events on a buffer', function(done) {
+        var stream = replacePlugin('world', 'elephant')
+        .on('finish', function() {
+          // No assertion required, we should end up here, if we don't the test will time out
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+    });
+
     it('should replace string on a stream', function(done) {
       var file = new File({
         path: 'test/fixtures/helloworld.txt',
@@ -25,27 +147,6 @@ describe('gulp-replace', function() {
           data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-    it('should replace string on a buffer', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
-
-      var stream = replacePlugin('world', 'person');
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-        done();
       });
 
       stream.write(file);
@@ -75,26 +176,6 @@ describe('gulp-replace', function() {
       stream.end();
     });
 
-    it('should replace regex on a buffer', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
-
-      var stream = replacePlugin(/world/g, 'person');
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-        done();
-      });
-
-      stream.write(file);
-      stream.end();
-    });
 
     it('should replace regex on a stream with a function', function(done) {
       var file = new File({
@@ -119,26 +200,7 @@ describe('gulp-replace', function() {
       stream.end();
     });
 
-    it('should replace regex on a buffer with a function', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
 
-      var stream = replacePlugin(/world/g, function() { return 'person'; });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-        done();
-      });
-
-      stream.write(file);
-      stream.end();
-    });
 
     it('should replace string on a stream with a function', function(done) {
       var file = new File({
@@ -163,26 +225,7 @@ describe('gulp-replace', function() {
       stream.end();
     });
 
-    it('should replace string on a buffer with a function', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
 
-      var stream = replacePlugin('world', function() { return 'person'; });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-        done();
-      });
-
-      stream.write(file);
-      stream.end();
-    });
 
     it('should call function once for each replacement when replacing a string on a stream', function(done) {
       var file = new File({
@@ -242,59 +285,9 @@ describe('gulp-replace', function() {
       stream.end();
     });
 
-    it('should call function once for each replacement when replacing a string on a buffer', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
 
-      var replacements = [
-        'cow',
-        'chicken',
-        'duck',
-        'person'
-      ];
-      var stream = replacePlugin('world', function() { return replacements.shift(); });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
 
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-        done();
-      });
 
-      stream.write(file);
-      stream.end();
-    });
-
-    it('should call function once for each replacement when replacing a regex on a buffer', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
-
-      var replacements = [
-        'cow',
-        'chicken',
-        'duck',
-        'person'
-      ];
-      var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-        done();
-      });
-
-      stream.write(file);
-      stream.end();
-    });
 
     it('should ignore binary files when skipBinary is enabled', function(done) {
       var file = new File({
@@ -340,22 +333,6 @@ describe('gulp-replace', function() {
       stream.end();
     });
 
-    it('should trigger events on a buffer', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/helloworld.txt')
-      });
 
-      var stream = replacePlugin('world', 'elephant')
-      .on('finish', function() {
-        // No assertion required, we should end up here, if we don't the test will time out
-        done();
-      });
-
-      stream.write(file);
-      stream.end();
-    });
   });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -340,7 +340,7 @@ describe('gulp-replace', function() {
       stream.end();
     });
 
-    it('should trigger events on a stream', function(done) {
+    it('should trigger events on a buffer', function(done) {
       var file = new File({
         path: 'test/fixtures/helloworld.txt',
         cwd: 'test/',
@@ -350,7 +350,7 @@ describe('gulp-replace', function() {
 
       var stream = replacePlugin('world', 'elephant')
       .on('finish', function() {
-        // No assertion required, we should end up here, if we don't the test will time out 
+        // No assertion required, we should end up here, if we don't the test will time out
         done();
       });
 

--- a/test/main.js
+++ b/test/main.js
@@ -112,164 +112,126 @@ describe('gulp-replace', function() {
       });
     });
 
-    it('should replace string on a stream', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
+    describe('streamed input', function () {
+      var file;
+
+      beforeEach(function () {
+        file = new File({
+            path: 'test/fixtures/helloworld.txt',
+            cwd: 'test/',
+            base: 'test/fixtures',
+            contents: fs.createReadStream('test/fixtures/helloworld.txt')
+          });
       });
 
-      var stream = replacePlugin('world', 'person');
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
+      it('should replace string on a stream', function(done) {
+        var stream = replacePlugin('world', 'person');
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
 
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        }));
+          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+            done();
+          }));
+        });
+
+        stream.write(file);
+        stream.end();
       });
 
-      stream.write(file);
-      stream.end();
+      it('should replace regex on a stream', function(done) {
+        var stream = replacePlugin(/world/g, 'person');
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+            done();
+          }));
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should replace regex on a stream with a function', function(done) {
+        var stream = replacePlugin(/world/g, function() { return 'person'; });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+            done();
+          }));
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should replace string on a stream with a function', function(done) {
+        var stream = replacePlugin('world', function() { return 'person'; });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+            done();
+          }));
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should call function once for each replacement when replacing a string on a stream', function(done) {
+        var replacements = [
+          'cow',
+          'chicken',
+          'duck',
+          'person'
+        ];
+        var stream = replacePlugin('world', function() { return replacements.shift(); });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+            data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
+            done();
+          }));
+        });
+
+        stream.write(file);
+        stream.end();
+      });
+
+      it('should call function once for each replacement when replacing a regex on a stream', function(done) {
+        var replacements = [
+          'cow',
+          'chicken',
+          'duck',
+          'person'
+        ];
+        var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
+        stream.on('data', function(newFile) {
+          should.exist(newFile);
+          should.exist(newFile.contents);
+
+          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+            data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
+            done();
+          }));
+        });
+
+        stream.write(file);
+        stream.end();
+      });
     });
-
-    it('should replace regex on a stream', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
-      });
-
-      var stream = replacePlugin(/world/g, 'person');
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-
-    it('should replace regex on a stream with a function', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
-      });
-
-      var stream = replacePlugin(/world/g, function() { return 'person'; });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-
-
-    it('should replace string on a stream with a function', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
-      });
-
-      var stream = replacePlugin('world', function() { return 'person'; });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-
-
-    it('should call function once for each replacement when replacing a string on a stream', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
-      });
-
-      var replacements = [
-        'cow',
-        'chicken',
-        'duck',
-        'person'
-      ];
-      var stream = replacePlugin('world', function() { return replacements.shift(); });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-          done();
-        }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-    it('should call function once for each replacement when replacing a regex on a stream', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
-      });
-
-      var replacements = [
-        'cow',
-        'chicken',
-        'duck',
-        'person'
-      ];
-      var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-          done();
-        }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-
-
-
 
     it('should ignore binary files when skipBinary is enabled', function(done) {
       var file = new File({

--- a/test/main.js
+++ b/test/main.js
@@ -177,8 +177,6 @@ describe('gulp-replace', function() {
         it('should ignore binary files when skipBinary is enabled', function(done) {
           var file = new File({
             path: 'test/fixtures/binary.png',
-            cwd: 'test/',
-            base: 'test/fixtures',
             contents: fs.readFileSync('test/fixtures/binary.png')
           });
 
@@ -194,8 +192,6 @@ describe('gulp-replace', function() {
         it('should replace string on non binary files when skipBinary is enabled', function(done) {
           var file = new File({
             path: 'test/fixtures/helloworld.txt',
-            cwd: 'test/',
-            base: 'test/fixtures',
             contents: fs.createReadStream('test/fixtures/helloworld.txt')
           });
 

--- a/test/main.js
+++ b/test/main.js
@@ -20,86 +20,78 @@ describe('gulp-replace', function() {
     });
 
     describe('buffered input', function () {
-      var file;
+      var file, check;
 
       beforeEach(function () {
         file = new File({
           path: 'test/fixtures/helloworld.txt',
           contents: fs.readFileSync('test/fixtures/helloworld.txt')
         });
+
+        check = function (stream, done, cb) {
+          stream.on('data', function (newFile) {
+            cb(newFile);
+            done();
+          });
+
+          stream.write(file);
+          stream.end();
+        };
       });
 
       it('should replace string on a buffer', function(done) {
         var stream = replacePlugin('world', 'person');
-        stream.on('data', function(newFile) {
-          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        });
 
-        stream.write(file);
-        stream.end();
+        check(stream, done, function (newFile) {
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+        });
       });
 
       it('should replace regex on a buffer', function(done) {
         var stream = replacePlugin(/world/g, 'person');
-        stream.on('data', function(newFile) {
-          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        });
 
-        stream.write(file);
-        stream.end();
+        check(stream, done, function (newFile) {
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+        });
       });
 
       it('should replace regex on a buffer with a function', function(done) {
         var stream = replacePlugin(/world/g, function() { return 'person'; });
-        stream.on('data', function(newFile) {
-          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        });
 
-        stream.write(file);
-        stream.end();
+        check(stream, done, function (newFile) {
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+        });
       });
 
       it('should replace string on a buffer with a function', function(done) {
         var stream = replacePlugin('world', function() { return 'person'; });
-        stream.on('data', function(newFile) {
-          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        });
 
-        stream.write(file);
-        stream.end();
+        check(stream, done, function (newFile) {
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+        });
       });
 
 
       it('should call function once for each replacement when replacing a string on a buffer', function(done) {
         var stream = replacePlugin('world', function() { return replacements.shift(); });
-        stream.on('data', function(newFile) {
-          String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-          done();
-        });
+        check(stream, done, function (newFile) {
 
-        stream.write(file);
-        stream.end();
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
+        });
       });
 
 
       it('should call function once for each replacement when replacing a regex on a buffer', function(done) {
         var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
-        stream.on('data', function(newFile) {
-          String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-          done();
-        });
 
-        stream.write(file);
-        stream.end();
+        check(stream, done, function (newFile) {
+          String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
+        });
       });
 
       it('should trigger events on a buffer', function(done) {
         var stream = replacePlugin('world', 'elephant')
-        .on('finish', function() {
+        stream.on('finish', function() {
           // No assertion required, we should end up here, if we don't the test will time out
           done();
         });
@@ -110,91 +102,67 @@ describe('gulp-replace', function() {
     });
 
     describe('streamed input', function () {
-      var file;
+      var file, check;
 
       beforeEach(function () {
         file = new File({
-            path: 'test/fixtures/helloworld.txt',
-            contents: fs.createReadStream('test/fixtures/helloworld.txt')
+          path: 'test/fixtures/helloworld.txt',
+          contents: fs.createReadStream('test/fixtures/helloworld.txt')
+        });
+
+        check = function (stream, done, cb) {
+          stream.on('data', function(newFile) {
+            newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+              cb(data);
+              done();
+            }));
           });
+
+          stream.write(file);
+          stream.end();
+        };
       });
 
       it('should replace string on a stream', function(done) {
         var stream = replacePlugin('world', 'person');
-        stream.on('data', function(newFile) {
-          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-            done();
-          }));
+        check(stream, done, function (data) {
+          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
         });
-
-        stream.write(file);
-        stream.end();
       });
 
       it('should replace regex on a stream', function(done) {
         var stream = replacePlugin(/world/g, 'person');
-        stream.on('data', function(newFile) {
-          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-            done();
-          }));
+        check(stream, done, function (data) {
+          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
         });
-
-        stream.write(file);
-        stream.end();
       });
 
       it('should replace regex on a stream with a function', function(done) {
         var stream = replacePlugin(/world/g, function() { return 'person'; });
-        stream.on('data', function(newFile) {
-          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-            done();
-          }));
+        check(stream, done, function (data) {
+          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
         });
-
-        stream.write(file);
-        stream.end();
       });
 
       it('should replace string on a stream with a function', function(done) {
         var stream = replacePlugin('world', function() { return 'person'; });
-        stream.on('data', function(newFile) {
-          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-            data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-            done();
-          }));
+        check(stream, done, function (data) {
+          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
         });
-
-        stream.write(file);
-        stream.end();
       });
 
       it('should call function once for each replacement when replacing a string on a stream', function(done) {
         var stream = replacePlugin('world', function() { return replacements.shift(); });
-        stream.on('data', function(newFile) {
-          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-            data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-            done();
-          }));
+        check(stream, done, function (data) {
+          data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
         });
-
-        stream.write(file);
-        stream.end();
       });
 
       it('should call function once for each replacement when replacing a regex on a stream', function(done) {
         var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
-        stream.on('data', function(newFile) {
-          newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-            data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
-            done();
-          }));
+        check(stream, done, function (data) {
+          data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
         });
-
-        stream.write(file);
-        stream.end();
       });
     });
 

--- a/test/main.js
+++ b/test/main.js
@@ -127,9 +127,6 @@ describe('gulp-replace', function() {
       it('should replace string on a stream', function(done) {
         var stream = replacePlugin('world', 'person');
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
             data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
             done();
@@ -143,9 +140,6 @@ describe('gulp-replace', function() {
       it('should replace regex on a stream', function(done) {
         var stream = replacePlugin(/world/g, 'person');
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
             data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
             done();
@@ -159,9 +153,6 @@ describe('gulp-replace', function() {
       it('should replace regex on a stream with a function', function(done) {
         var stream = replacePlugin(/world/g, function() { return 'person'; });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
             data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
             done();
@@ -175,9 +166,6 @@ describe('gulp-replace', function() {
       it('should replace string on a stream with a function', function(done) {
         var stream = replacePlugin('world', function() { return 'person'; });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
             data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
             done();
@@ -197,9 +185,6 @@ describe('gulp-replace', function() {
         ];
         var stream = replacePlugin('world', function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
             data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
             done();
@@ -219,9 +204,6 @@ describe('gulp-replace', function() {
         ];
         var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
             data.should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
             done();

--- a/test/main.js
+++ b/test/main.js
@@ -204,6 +204,12 @@ describe('gulp-replace', function() {
 
     describe('options', function () {
       describe('skipBinary', function () {
+        var stream;
+
+        beforeEach(function () {
+          stream = replacePlugin('world', 'person', {skipBinary: true});
+        });
+
         it('should ignore binary files when skipBinary is enabled', function(done) {
           var file = new File({
             path: 'test/fixtures/binary.png',
@@ -212,7 +218,6 @@ describe('gulp-replace', function() {
             contents: fs.readFileSync('test/fixtures/binary.png')
           });
 
-          var stream = replacePlugin('world', 'person', {skipBinary: true});
           stream.on('data', function(newFile) {
             newFile.contents.should.eql(fs.readFileSync('test/expected/binary.png'));
             done();
@@ -230,7 +235,6 @@ describe('gulp-replace', function() {
             contents: fs.createReadStream('test/fixtures/helloworld.txt')
           });
 
-          var stream = replacePlugin('world', 'person', {skipBinary: true});
           stream.on('data', function(newFile) {
             newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
               data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));

--- a/test/main.js
+++ b/test/main.js
@@ -25,8 +25,6 @@ describe('gulp-replace', function() {
       beforeEach(function () {
         file = new File({
           path: 'test/fixtures/helloworld.txt',
-          cwd: 'test/',
-          base: 'test/fixtures',
           contents: fs.readFileSync('test/fixtures/helloworld.txt')
         });
       });
@@ -117,8 +115,6 @@ describe('gulp-replace', function() {
       beforeEach(function () {
         file = new File({
             path: 'test/fixtures/helloworld.txt',
-            cwd: 'test/',
-            base: 'test/fixtures',
             contents: fs.createReadStream('test/fixtures/helloworld.txt')
           });
       });

--- a/test/main.js
+++ b/test/main.js
@@ -23,9 +23,6 @@ describe('gulp-replace', function() {
       it('should replace string on a buffer', function(done) {
         var stream = replacePlugin('world', 'person');
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         });
@@ -37,9 +34,6 @@ describe('gulp-replace', function() {
       it('should replace regex on a buffer', function(done) {
         var stream = replacePlugin(/world/g, 'person');
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         });
@@ -51,9 +45,6 @@ describe('gulp-replace', function() {
       it('should replace regex on a buffer with a function', function(done) {
         var stream = replacePlugin(/world/g, function() { return 'person'; });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         });
@@ -65,9 +56,6 @@ describe('gulp-replace', function() {
       it('should replace string on a buffer with a function', function(done) {
         var stream = replacePlugin('world', function() { return 'person'; });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
           done();
         });
@@ -86,9 +74,6 @@ describe('gulp-replace', function() {
         ];
         var stream = replacePlugin('world', function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
           done();
         });
@@ -107,9 +92,6 @@ describe('gulp-replace', function() {
         ];
         var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
-          should.exist(newFile);
-          should.exist(newFile.contents);
-
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
           done();
         });

--- a/test/main.js
+++ b/test/main.js
@@ -8,6 +8,17 @@ var File = require('vinyl');
 
 describe('gulp-replace', function() {
   describe('replacePlugin()', function() {
+    var replacements;
+
+    beforeEach(function () {
+      replacements = [
+        'cow',
+        'chicken',
+        'duck',
+        'person'
+      ];
+    });
+
     describe('buffered input', function () {
       var file;
 
@@ -66,12 +77,6 @@ describe('gulp-replace', function() {
 
 
       it('should call function once for each replacement when replacing a string on a buffer', function(done) {
-        var replacements = [
-          'cow',
-          'chicken',
-          'duck',
-          'person'
-        ];
         var stream = replacePlugin('world', function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
@@ -84,12 +89,6 @@ describe('gulp-replace', function() {
 
 
       it('should call function once for each replacement when replacing a regex on a buffer', function(done) {
-        var replacements = [
-          'cow',
-          'chicken',
-          'duck',
-          'person'
-        ];
         var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
           String(newFile.contents).should.equal(fs.readFileSync('test/expected/hellofarm.txt', 'utf8'));
@@ -177,12 +176,6 @@ describe('gulp-replace', function() {
       });
 
       it('should call function once for each replacement when replacing a string on a stream', function(done) {
-        var replacements = [
-          'cow',
-          'chicken',
-          'duck',
-          'person'
-        ];
         var stream = replacePlugin('world', function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
@@ -196,12 +189,6 @@ describe('gulp-replace', function() {
       });
 
       it('should call function once for each replacement when replacing a regex on a stream', function(done) {
-        var replacements = [
-          'cow',
-          'chicken',
-          'duck',
-          'person'
-        ];
         var stream = replacePlugin(/world/g, function() { return replacements.shift(); });
         stream.on('data', function(newFile) {
           newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {

--- a/test/main.js
+++ b/test/main.js
@@ -215,50 +215,47 @@ describe('gulp-replace', function() {
       });
     });
 
-    it('should ignore binary files when skipBinary is enabled', function(done) {
-      var file = new File({
-        path: 'test/fixtures/binary.png',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.readFileSync('test/fixtures/binary.png')
+    describe('options', function () {
+      describe('skipBinary', function () {
+        it('should ignore binary files when skipBinary is enabled', function(done) {
+          var file = new File({
+            path: 'test/fixtures/binary.png',
+            cwd: 'test/',
+            base: 'test/fixtures',
+            contents: fs.readFileSync('test/fixtures/binary.png')
+          });
+
+          var stream = replacePlugin('world', 'person', {skipBinary: true});
+          stream.on('data', function(newFile) {
+            newFile.contents.should.eql(fs.readFileSync('test/expected/binary.png'));
+            done();
+          });
+
+          stream.write(file);
+          stream.end();
+        });
+
+        it('should replace string on non binary files when skipBinary is enabled', function(done) {
+          var file = new File({
+            path: 'test/fixtures/helloworld.txt',
+            cwd: 'test/',
+            base: 'test/fixtures',
+            contents: fs.createReadStream('test/fixtures/helloworld.txt')
+          });
+
+          var stream = replacePlugin('world', 'person', {skipBinary: true});
+          stream.on('data', function(newFile) {
+            newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
+              data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
+              done();
+            }));
+          });
+
+          stream.write(file);
+          stream.end();
+        });
+
       });
-
-      var stream = replacePlugin('world', 'person', {skipBinary: true});
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.should.eql(fs.readFileSync('test/expected/binary.png'));
-        done();
-      });
-
-      stream.write(file);
-      stream.end();
     });
-
-    it('should replace string on non binary files when skipBinary is enabled', function(done) {
-      var file = new File({
-        path: 'test/fixtures/helloworld.txt',
-        cwd: 'test/',
-        base: 'test/fixtures',
-        contents: fs.createReadStream('test/fixtures/helloworld.txt')
-      });
-
-      var stream = replacePlugin('world', 'person', {skipBinary: true});
-      stream.on('data', function(newFile) {
-        should.exist(newFile);
-        should.exist(newFile.contents);
-
-        newFile.contents.pipe(concatStream({encoding: 'string'}, function(data) {
-          data.should.equal(fs.readFileSync('test/expected/helloworld.txt', 'utf8'));
-          done();
-        }));
-      });
-
-      stream.write(file);
-      stream.end();
-    });
-
-
   });
 });


### PR DESCRIPTION
## A bunch of changes: 
- trying to remove as much repetition as possible (particularly in test initialization) by moving initialization into `beforeEach` blocks
- grouping tests in logical groups
- removing test environment (test file existence) tests — there's no need to test environment together with the code
- replaces `stream` with a `buffer` in a test case name

## Questions
Seems like reading-writing test files in every test case is rather useless and, even worse, makes tests code too complicated. Ideally, each test case should consist only of one check, but I don't know yet how to achieve such simplicity. Maybe you have any thoughts?

I also wonder why are the file parameters such as `cwd` and `base` needed. Once I remove them nothing happens, but I don't sure if this is a regression-safe change.