### PR TITLE
Passes full file path to the replacement function

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,20 +55,29 @@ module.exports = function(search, replacement, options) {
         callback(null, file);
       }
 
-      if (options && options.skipBinary) {
-        istextorbinary.isText(file.path, file.contents, function(err, result) {
-          if (err) {
-            return callback(err, file);
+      if (options) {
+        if (options.passFilename && typeof replacement === 'function') {
+          var userReplacement = replacement;
+          replacement = function (match) {
+            userReplacement(match, file.path);
           }
+        }
 
-          if (!result) {
-            callback(null, file);
-          } else {
-            doReplace();
-          }
-        });
+        if (options.skipBinary) {
+          istextorbinary.isText(file.path, file.contents, function(err, result) {
+            if (err) {
+              return callback(err, file);
+            }
 
-        return;
+            if (!result) {
+              callback(null, file);
+            } else {
+              doReplace();
+            }
+          });
+
+          return;
+        }
       }
 
       doReplace();

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function(search, replacement, options) {
           var userReplacement = replacement;
           replacement = function (match) {
             userReplacement(match, file.path);
-          }
+          };
         }
 
         if (options.skipBinary) {


### PR DESCRIPTION
Larry, hi!

The PR solves https://github.com/lazd/gulp-replace/issues/50 issue passing file name with a full path in all possible cases: 
- the replace is done on a stream, with a regex or string passed like a replacement
- the replace is applied to a buffer, also no matter if one wants to match a string or a regex
## New option

In order to use this functionality one should use new option `passFilename` which should be set to `true` (as well as pass a function as a replacement), and therefore the callback will be called with two arguments, where the second is file path.
## Callback signature

In the previous version callback could have been invoked with only 1 argument or with a bunch of them as standard `String.replace` do. 
## Backwards compatibility

As mentioned above, the new option is proposed to keep users in safe backwards compatibility state after an update to the last version. 
## ToDo and questions

The PR is not completed yet because of the absence of tests and documentation. I'll add them as soon as #66 would have been merged. Please look at both PRs and let me know if something is wrong or you had another evolution plan.

The main question is, should the major release be introduced only because of backwards incompatibility, or should it be done just because of the existing evolution plan? 
