### PR TITLE
Refactor the documentation-comments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,23 @@
 /**
- * replace
- * gulp-replace can be called with a string or regex.
+ * Searches and replaces a portion of text using a `string` or a `RegExp`.
  *
- * @param search       The string or regex to search for
+ * @param search       The `string` or `RegExp` to search for.
  *
- * @param _replacement The replacement string or function.
- *                     <p>If replacement is a function, it will be called once for each match and will be passed the string
+ * @param replacement  The replacement string or a function for generating a replacement.
+ *
+ *                     If `replacement` is a function, it will be called once for each match and will be passed the string
  *                     that is to be replaced. The value of `this.file` will be equal to the vinyl instance for the file
- *                     being processed.</p>
- *                     Read more at
- *                     <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter">String.prototype.replace() at MDN web docs</a>
+ *                     being processed.
  *
- * @param options     `options.skipBinary` will be equal to `true` by default.
- *                     <p>Skip binary files. This option is true by default. If
- *                     you want to replace content in binary files, you must explicitly set it to false</p>
+ *                     Read more at [`String.prototype.replace()` at MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter").
  *
+ * @param options      `options.skipBinary` will be equal to `true` by default.
+ *
+ *                     Skip binary files. This option is `true` by default. If
+ *                     you want to replace content in binary files, you must explicitly set it to `false`.
  */
 export declare function replace(
     search: string | RegExp,
-    _replacement: string | (() => string) | ((search: string, ...args: any[]) => string),
+    replacement: string | (() => string) | ((search: string, ...args: any[]) => string),
     options?: { skipBinary: boolean }
 ): any; /* The type of return value should not be `any`, but I could not find the types definition of  */


### PR DESCRIPTION
As JSDoc supports plain markdown, I refactored the design of the documentation comments a little