### PR TITLE
Permit any version of @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.3",
   "description": "A string replace plugin for gulp",
   "dependencies": {
-    "@types/node": "^14.14.41",
+    "@types/node": "*",
     "@types/vinyl": "^2.0.4",
     "istextorbinary": "^3.0.0",
     "replacestream": "^4.0.3",


### PR DESCRIPTION
Projects that use gulp-replace cannot currenlty be built with TypeScript 4.9 because gulp-replace depends on an old major version of @types/node.

A quick survey of a few of my other dependencies that require @types/node shows that most of them accept any version (`"*"`).

This seems like the best solution for gulp-replace too.

See microsoft/TypeScript#51567.